### PR TITLE
Railsの初期設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,14 @@ module ProwrestNumarasu
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 
+    # タイムゾーン設定
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
+
+    # 言語設定
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files
@@ -33,5 +41,9 @@ module ProwrestNumarasu
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.generators do |g|
+      g.helper false # helperを自動生成しない
+    end
   end
 end


### PR DESCRIPTION
## 概要
Closes #7 

- `rails g`実行時に、helperが生成されないよう設定しました。
- デフォルトのタイムゾーンを日本に設定しました
- デフォルトの言語を日本語に設定しました。

## 確認方法

- `rails g`を行い、helperが生成されないことを確認
- rails console上で、デフォルトのタイムゾーンが日本であることを確認
- rails console上で、デフォルトの言語が日本語であることを確認

## 確認結果
`rails g`
[![Image from Gyazo](https://i.gyazo.com/e73a3b430d39dda74182d7a553a24de0.png)](https://gyazo.com/e73a3b430d39dda74182d7a553a24de0)

`rails c`
[![Image from Gyazo](https://i.gyazo.com/cfb695ee9e5657fe4edceb28e681d957.png)](https://gyazo.com/cfb695ee9e5657fe4edceb28e681d957)