### PR TITLE
フラッシュ・エラーメッセージの追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   before_action :require_login
 
+  add_flash_types :success, :info, :warning, :danger
+
   private
   
   def not_authenticated

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -7,15 +7,16 @@ class UserSessionsController < ApplicationController
     @user = login(params[:email], params[:password])
 
     if @user
-      redirect_back_or_to root_url
+      redirect_back_or_to root_path, success: t('.success')
     else
+      flash.now[:danger] = t('.fail')
       render :new
     end
   end
 
   def destroy
     logout
-    redirect_to root_url
+    redirect_to root_path, success: t('.success')
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,12 @@ class UsersController < ApplicationController
 
   def create
     @user = User.new(user_params)
-    @user.save
+    if @user.save
+      redirect_to login_path, success: t('.success')
+    else
+      flash.now[:danger] = t('.fail')
+      render :new
+    end
   end
 
   private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,10 +12,11 @@
 
   <body>
     <% if logged_in? %>
-      <%= render partial: 'shared/header' %>
+      <%= render 'shared/header' %>
     <% else %>
-      <%= render partial: 'shared/before_login_header' %>
+      <%= render 'shared/before_login_header' %>
     <% end %>
+    <%= render 'shared/flash_message' %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div class="alert alert-danger">
+    <ul class="mb-0">
+      <% object.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,3 @@
+<% flash.each do |message_type, message| %>
+  <div class="alert alert-<%= message_type %>"><%= message %></div>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,7 +3,8 @@
     <h2 class="text-accent-content text-2xl lg:text-3xl font-bold text-center text-red-500 text-5xl font-mono"><%= t '.title' %></h2>
     <div class="max-w-xl border rounded-xl mx-auto">
       <div class="flex flex-col bg-stone-50 gap-4 p-4 md:p-8 ">
-        <%= form_with model: @user, local: true do |f|%>
+        <%= form_with model: @user, local: true do |f| %>
+          <%= render 'shared/error_messages', object: f.object %>
           <div class="form-control mb-10">
             <%= f.label :name, class: 'form-control' %>
             <%= f.text_field :name, class: 'input input-accent' %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -7,6 +7,14 @@ ja:
   users:
     new:
       title: "ユーザー登録"
+    create: 
+      success: "ユーザー登録が完了しました"
+      fail: 'ユーザー登録に失敗しました'
   user_sessions:
     new:
       title: "ログイン"
+    create:
+      success: 'ログインしました'
+      fail: 'ログインに失敗しました'
+    destroy:
+      success: 'ログアウトしました'


### PR DESCRIPTION
## 概要
ログイン、新規ユーザー登録時にフラッシュメッセージが表示されるよう設定。
新規ユーザー登録時のバリデーションエラーには個別のエラーメッセージが表示されるよう設定。

## 確認方法
ログイン、新規ユーザー登録でフラッシュ・エラーメッセージが出るか確認

## コメント
後でUIを整える必要がある