### PR TITLE
グループチャット機能のテーブル、モデルの作成

### DIFF
--- a/app/models/chat_group.rb
+++ b/app/models/chat_group.rb
@@ -1,0 +1,9 @@
+class ChatGroup < ApplicationRecord
+  has_many :chat_group_users
+  has_many :users, through: :chat_group_users
+  has_many :messages, dependent: :destroy
+
+  mount_uploader :image, ImageUploader
+
+  validates :group_name, presence: true, length: { maximum: 255 }
+end

--- a/app/models/chat_group_user.rb
+++ b/app/models/chat_group_user.rb
@@ -1,0 +1,4 @@
+class ChatGroupUser < ApplicationRecord
+  belongs_to :user
+  belongs_to :chat_group
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,8 @@
+class Message < ApplicationRecord
+  belongs_to :user
+  belongs_to :chat_group
+
+  mount_uploader :image, ImageUploader
+
+  validates :body, presence: true, length: { maximum: 65_535 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,9 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :like_posts, through: :likes, source: :post
   has_many :questions, dependent: :destroy
+  has_many :chat_group_users
+  has_many :chat_groups, through: :chat_group_users
+  has_many :messages, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 255 }
   validates :email, presence: true, uniqueness: true

--- a/db/migrate/20230323060610_create_chat_groups.rb
+++ b/db/migrate/20230323060610_create_chat_groups.rb
@@ -1,0 +1,11 @@
+class CreateChatGroups < ActiveRecord::Migration[7.0]
+  def change
+    create_table :chat_groups do |t|
+      t.string :image
+      t.string :group_name, null: false
+      t.text :group_description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230323062354_create_chat_group_users.rb
+++ b/db/migrate/20230323062354_create_chat_group_users.rb
@@ -1,0 +1,10 @@
+class CreateChatGroupUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :chat_group_users do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :chat_group, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230323094307_create_messages.rb
+++ b/db/migrate/20230323094307_create_messages.rb
@@ -1,0 +1,12 @@
+class CreateMessages < ActiveRecord::Migration[7.0]
+  def change
+    create_table :messages do |t|
+      t.text :body, null: false
+      t.string :image
+      t.references :user, null: false, foreign_key: true
+      t.references :chat_group, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_13_080322) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_23_094307) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "chat_group_users", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "chat_group_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["chat_group_id"], name: "index_chat_group_users_on_chat_group_id"
+    t.index ["user_id"], name: "index_chat_group_users_on_user_id"
+  end
+
+  create_table "chat_groups", force: :cascade do |t|
+    t.string "image"
+    t.string "group_name", null: false
+    t.text "group_description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "choices", force: :cascade do |t|
     t.string "body", null: false
@@ -41,6 +58,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_13_080322) do
     t.index ["post_id"], name: "index_likes_on_post_id"
     t.index ["user_id", "post_id"], name: "index_likes_on_user_id_and_post_id", unique: true
     t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
+  create_table "messages", force: :cascade do |t|
+    t.text "body", null: false
+    t.string "image"
+    t.bigint "user_id", null: false
+    t.bigint "chat_group_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["chat_group_id"], name: "index_messages_on_chat_group_id"
+    t.index ["user_id"], name: "index_messages_on_user_id"
   end
 
   create_table "posts", force: :cascade do |t|
@@ -94,11 +122,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_13_080322) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "chat_group_users", "chat_groups"
+  add_foreign_key "chat_group_users", "users"
   add_foreign_key "choices", "questions"
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
+  add_foreign_key "messages", "chat_groups"
+  add_foreign_key "messages", "users"
   add_foreign_key "posts", "users"
   add_foreign_key "questions", "users"
   add_foreign_key "taggings", "posts"

--- a/spec/factories/chat_group_users.rb
+++ b/spec/factories/chat_group_users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :chat_group_user do
+    user { nil }
+    chat_group { nil }
+  end
+end

--- a/spec/factories/chat_groups.rb
+++ b/spec/factories/chat_groups.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :chat_group do
+    image { "MyString" }
+    group_name { "MyString" }
+    group_description { "MyText" }
+  end
+end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :message do
+    body { "MyText" }
+    image { "MyString" }
+    user { nil }
+    chat_group { nil }
+  end
+end

--- a/spec/models/chat_group_spec.rb
+++ b/spec/models/chat_group_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ChatGroup, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/chat_group_user_spec.rb
+++ b/spec/models/chat_group_user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ChatGroupUser, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Message, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
グループチャット機能のテーブル、モデルの作成
## 概要
Closes #24 
グループチャット機能のchat_groupsテーブル、ChatGroupモデル、chat_group_usersテーブル、ChatGroupUserモデル、messagesテーブル、Messageモデルを作成。

## 確認方法

-  chat_groupsとusersを多対多のアソシエーションになっている

-  chat_groupsとusersの中間テーブルにchat_group_usersを設定されている

-  usersとmessagesを1対多のアソシエーションになっている

-  chat_groupsとmessagesを1対多のアソシエーションになっている

chat_groupsテーブル

 image : string
 group_name : string（必須）
 group_description : text

messagesテーブル

 body : text（必須）
 image : string

バリデーション

ChatGroupモデル
group_nameカラムが必須、255文字以内

Messageモデル
bodyカラムが必須、65535文字以内