### PR TITLE
新規作成ページの注意事項文追加

### DIFF
--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -21,14 +21,14 @@ ja:
         image: "画像"
         url: "YouTube"
         tag_names: "タグ"
-        organization: "*団体"
+        organization: "*団体（編集時も必ず選択してください）"
       question:
         title: "タイトル"
         image: "画像"
         url: "YouTube"
         sentence: "*問題文"
         increase: "＋選択肢を増やす"
-        organization: "*団体"
+        organization: "*団体（編集時も必ず選択してください）"
       choice:
         body: "*選択肢"
         correct_answer: "正解・不正解"
@@ -41,7 +41,7 @@ ja:
         group_name: "*グループ名"
         group_description: "グループ説明"
         image: "画像"
-        organization: "*団体"
+        organization: "*団体（編集時も必ず選択してください）"
   attributes:
     id: "ID"
     created_at: "作成日時"


### PR DESCRIPTION
## 概要
編集時に団体選択肢ないとエラー画面が表示されてしまうので、注意事項文を追加。

## 確認方法
新規作成画面の団体項目の文字の隣に（編集時にも選択してください）という文があること。